### PR TITLE
Fix run_sde.sh

### DIFF
--- a/code/run_sde.sh
+++ b/code/run_sde.sh
@@ -1,1 +1,1 @@
-python main_run_sdedit.py --init_aud audio_text_pairs/addition/e1.wav --cfg_tar 3 --target_prompt "A church bell ringing with loud baby crying in the background." --num_diffusion_steps 100  --wandb_disable
+python main_run_sdedit.py --init_aud audio_text_pairs/addition/e1.wav --cfg_tar 3 --target_prompt "A church bell ringing with loud baby crying in the background." --num_diffusion_steps 100 --tstart 50 --wandb_disable


### PR DESCRIPTION
The issue is that they use a weird convention for specifying the number of timesteps.
`skip = args.num_diffusion_steps - args.tstart`
So with the specified values (`num_diffusion_steps=100` and `tstart=0`) => `skip=100`, so all the timesteps are skipped and the `timesteps = timesteps[skip:]` tensor is empty (`shape = [0]`). Hence you get the error `IndexError: index 0 is out of bounds for dimension 0 with size 0` because we try to index the first element of an empty tensor.
For example, if you set `tstart=50` the edit works fine.